### PR TITLE
fix: missing ALB/Load Balancer Controller

### DIFF
--- a/.github/workflows/eks_create_deploy.yaml
+++ b/.github/workflows/eks_create_deploy.yaml
@@ -67,6 +67,7 @@ jobs:
         cd $TF_WORKSPACE
         terraform apply -auto-approve
         echo "MINIO_IAM_ROLE_ARN=$(terraform output -raw minio_role_arn)" >> $GITHUB_ENV
+        echo "AWS_LOAD_BALANCER_CONTROLLER_ROLE_ARN=$(terraform output -raw aws_load_balancer_controller_role_arn)" >> $GITHUB_ENV
         cd -
 
 
@@ -77,6 +78,32 @@ jobs:
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
         aws eks update-kubeconfig --region $AWS_REGION --name ${{ env.TF_VAR_name_prefix }}-cluster
+
+    # Install AWS Load Balancer Controller
+    - name: Install AWS Load Balancer Controller
+      run: |
+        # Install Helm
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        
+        # Add EKS repository
+        helm repo add eks https://aws.github.io/eks-charts
+        helm repo update
+        
+        # Create service account for AWS Load Balancer Controller
+        kubectl create serviceaccount aws-load-balancer-controller -n kube-system
+        kubectl annotate serviceaccount aws-load-balancer-controller -n kube-system eks.amazonaws.com/role-arn=$AWS_LOAD_BALANCER_CONTROLLER_ROLE_ARN
+        
+        # Install AWS Load Balancer Controller
+        helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+          -n kube-system \
+          --set clusterName=${{ env.TF_VAR_name_prefix }}-cluster \
+          --set serviceAccount.create=false \
+          --set serviceAccount.name=aws-load-balancer-controller \
+          --set region=$AWS_REGION \
+          --set vpcId=$(kubectl get configmap aws-auth -n kube-system -o jsonpath='{.data.mapRoles}' | grep -o 'vpc-[a-zA-Z0-9]*' | head -1 || aws ec2 describe-vpcs --filters "Name=tag:Name,Values=${{ env.TF_VAR_name_prefix }}-vpc" --query "Vpcs[0].VpcId" --output text)
+        
+        # Wait for controller to be ready
+        kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=aws-load-balancer-controller -n kube-system --timeout=300s
 
 
     # Create a Kubernetes service account to be used by minio service; and associate it with the IAM role granted to EKS.
@@ -93,10 +120,26 @@ jobs:
 
     - name: Deploy MinIO on EKS
       run: |
-        kubectl apply -f ./k8s-app/minio.yaml
+        kubectl apply -f ./k8s-app/minio-improved.yaml
 
-    - name: Get the endpoint of the load balancer created for MinIO service
+    - name: Wait for MinIO deployment and get the endpoint
       run: |
+        # Wait for deployment to be ready
+        kubectl wait --for=condition=available --timeout=300s deployment/minio-deployment
+        
+        # Wait for load balancer to be provisioned
+        echo "Waiting for load balancer to be provisioned..."
+        for i in {1..30}; do
+          EXTERNAL_IP=$(kubectl get svc minio-service -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+          if [ ! -z "$EXTERNAL_IP" ]; then
+            echo "MinIO is accessible at: http://$EXTERNAL_IP"
+            echo "MinIO Console is accessible at: http://$EXTERNAL_IP:9001"
+            break
+          fi
+          echo "Waiting for external IP... (attempt $i/30)"
+          sleep 30
+        done
+        
         kubectl get svc minio-service
 
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,87 @@
+# EKS Deployment Troubleshooting Guide
+
+## Issues Found and Fixed
+
+### 1. **Missing AWS Load Balancer Controller**
+**Problem**: The cluster couldn't provision AWS Load Balancers for services of type `LoadBalancer`.
+**Solution**: Added AWS Load Balancer Controller installation to the GitHub Actions workflow.
+
+### 2. **Missing OIDC Provider**
+**Problem**: Service accounts couldn't assume IAM roles (required for IRSA).
+**Solution**: Added OIDC identity provider creation in `eks_cluster.tf`.
+
+### 3. **Incorrect Security Group Rules**
+**Problem**: Security group only allowed ports 80/443 but MinIO runs on port 9000.
+**Solution**: Added ingress rules for MinIO ports (9000, 9001) and internal VPC communication.
+
+### 4. **Missing Subnet Tags**
+**Problem**: AWS Load Balancer Controller couldn't discover subnets for load balancer placement.
+**Solution**: Added required Kubernetes tags to subnets:
+- `kubernetes.io/role/elb = 1`
+- `kubernetes.io/cluster/<cluster-name> = shared`
+
+### 5. **Outdated MinIO Configuration**
+**Problem**: MinIO configuration used deprecated environment variables and lacked proper health checks.
+**Solution**: Updated to use `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` and added health checks.
+
+## Verification Steps
+
+After deployment, verify the following:
+
+1. **Check AWS Load Balancer Controller is running:**
+   ```bash
+   kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller
+   ```
+
+2. **Check MinIO pods are running:**
+   ```bash
+   kubectl get pods -l app=minio
+   ```
+
+3. **Check service has external IP:**
+   ```bash
+   kubectl get svc minio-service
+   ```
+
+4. **Check load balancer in AWS Console:**
+   - Go to EC2 > Load Balancers
+   - Look for load balancer with your cluster name
+
+## Alternative Deployment Options
+
+### Option 1: Use ALB with Ingress (Recommended for production)
+Uncomment the Ingress section in `minio-improved.yaml` and comment out the LoadBalancer service.
+
+### Option 2: Use NodePort with manual Load Balancer
+Change service type to `NodePort` and create an ALB manually pointing to worker nodes.
+
+## Common Issues and Solutions
+
+### Load Balancer Stuck in Pending
+- Check AWS Load Balancer Controller logs: `kubectl logs -n kube-system deployment/aws-load-balancer-controller`
+- Verify subnet tags are correct
+- Check IAM permissions for the controller
+
+### MinIO Not Accessible
+- Verify security group rules allow traffic on MinIO ports
+- Check if pods are running: `kubectl describe pod <minio-pod-name>`
+- Verify service account annotations: `kubectl describe sa minio-serviceaccount`
+
+### S3 Access Issues
+- Check IAM role trust policy includes correct OIDC provider
+- Verify service account is annotated with correct IAM role ARN
+- Test S3 access from within the pod
+
+## Security Considerations
+
+1. **Restrict CIDR blocks**: Consider restricting `0.0.0.0/0` to specific IP ranges
+2. **Enable HTTPS**: Add SSL/TLS termination at the load balancer
+3. **Network policies**: Implement Kubernetes network policies for pod-to-pod communication
+4. **Secrets management**: Consider using AWS Secrets Manager instead of Kubernetes secrets
+
+## Cost Optimization
+
+1. **Instance types**: Consider using spot instances for non-production
+2. **Auto-scaling**: Enable cluster autoscaler for dynamic scaling
+3. **Load balancer**: NLB is cheaper than ALB for simple use cases
+4. **Storage**: Use gp3 volumes instead of gp2 for better price/performance

--- a/k8s-app/minio-improved.yaml
+++ b/k8s-app/minio-improved.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      serviceAccountName: minio-serviceaccount   # Service account used by minio to access a particular S3 bucket
+      containers:
+      - name: minio
+        image: minio/minio:latest
+        args:
+        - server
+        - /data
+        - --console-address
+        - ":9001"
+        env:
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: access_key
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: secret_key
+        ports:
+        - containerPort: 9000
+          name: minio-api
+        - containerPort: 9001
+          name: minio-console
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: minio-api
+      protocol: TCP
+      port: 80
+      targetPort: 9000
+    - name: minio-console
+      protocol: TCP
+      port: 9001
+      targetPort: 9001
+  type: LoadBalancer
+---
+# Alternative Ingress-based approach (uncomment if you prefer ALB over NLB)
+# apiVersion: networking.k8s.io/v1
+# kind: Ingress
+# metadata:
+#   name: minio-ingress
+#   annotations:
+#     kubernetes.io/ingress.class: alb
+#     alb.ingress.kubernetes.io/scheme: internet-facing
+#     alb.ingress.kubernetes.io/target-type: ip
+#     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+#     alb.ingress.kubernetes.io/ssl-redirect: '443'
+# spec:
+#   rules:
+#   - http:
+#       paths:
+#       - path: /
+#         pathType: Prefix
+#         backend:
+#           service:
+#             name: minio-service-internal
+#             port:
+#               number: 9000
+# ---
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: minio-service-internal
+# spec:
+#   selector:
+#     app: minio
+#   ports:
+#     - protocol: TCP
+#       port: 9000
+#       targetPort: 9000
+#   type: ClusterIP

--- a/terraform/eks_cluster.tf
+++ b/terraform/eks_cluster.tf
@@ -35,13 +35,32 @@ resource "aws_eks_cluster" "eks_cluster" {
   role_arn = aws_iam_role.eks_cluster.arn
   version  = var.k8s_version
   vpc_config {
-    subnet_ids         = [aws_subnet.subnet1.id, aws_subnet.subnet2.id]
-    security_group_ids = [aws_security_group.allow_http.id]
+    subnet_ids              = [aws_subnet.subnet1.id, aws_subnet.subnet2.id]
+    security_group_ids      = [aws_security_group.allow_http.id]
+    endpoint_config {
+      public_access  = true
+      private_access = true
+    }
   }
   depends_on = [
     aws_iam_role_policy_attachment.eks_cluster_policy,
     aws_iam_role_policy_attachment.eks_vpc_resource_controller,
   ]
+}
+
+# Create OIDC identity provider for the EKS cluster
+data "tls_certificate" "eks_cluster" {
+  url = aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "eks_cluster" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.eks_cluster.certificates[0].sha1_fingerprint]
+  url             = aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
+
+  tags = {
+    Name = "${var.name_prefix}-eks-oidc"
+  }
 }
 
 
@@ -184,4 +203,55 @@ resource "aws_iam_role_policy_attachment" "minio_s3_access" {
 output "minio_role_arn" {
   value       = aws_iam_role.minio_role.arn
   description = "The ARN of the IAM role associated with the MinIO service account."
+}
+
+
+
+
+#### AWS Load Balancer Controller IAM Role
+resource "aws_iam_role" "aws_load_balancer_controller" {
+  name = "${var.name_prefix}-aws-load-balancer-controller"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.eks_cluster.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(aws_iam_openid_connect_provider.eks_cluster.url, "https://", "")}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
+            "${replace(aws_iam_openid_connect_provider.eks_cluster.url, "https://", "")}:aud": "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${var.name_prefix}-aws-load-balancer-controller-role"
+  }
+}
+
+# Download AWS Load Balancer Controller IAM policy
+data "http" "aws_load_balancer_controller_policy" {
+  url = "https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.7.2/docs/install/iam_policy.json"
+}
+
+resource "aws_iam_policy" "aws_load_balancer_controller" {
+  name   = "${var.name_prefix}-AWSLoadBalancerControllerIAMPolicy"
+  policy = data.http.aws_load_balancer_controller_policy.response_body
+}
+
+resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller" {
+  policy_arn = aws_iam_policy.aws_load_balancer_controller.arn
+  role       = aws_iam_role.aws_load_balancer_controller.name
+}
+
+output "aws_load_balancer_controller_role_arn" {
+  value       = aws_iam_role.aws_load_balancer_controller.arn
+  description = "The ARN of the AWS Load Balancer Controller IAM role"
 }

--- a/terraform/networking.tf
+++ b/terraform/networking.tf
@@ -17,7 +17,9 @@ resource "aws_subnet" "subnet1" {
   map_public_ip_on_launch = true # Enable auto-assign public IP
 
   tags = {
-    Name = "${var.name_prefix}-subnet1"
+    Name                                        = "${var.name_prefix}-subnet1"
+    "kubernetes.io/role/elb"                   = "1"
+    "kubernetes.io/cluster/${var.name_prefix}-cluster" = "shared"
   }
 }
 
@@ -29,7 +31,9 @@ resource "aws_subnet" "subnet2" {
   map_public_ip_on_launch = true # Enable auto-assign public IP
 
   tags = {
-    Name = "${var.name_prefix}-subnet2"
+    Name                                        = "${var.name_prefix}-subnet2"
+    "kubernetes.io/role/elb"                   = "1"
+    "kubernetes.io/cluster/${var.name_prefix}-cluster" = "shared"
   }
 }
 
@@ -84,6 +88,31 @@ resource "aws_security_group" "allow_http" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "MinIO default port"
+    from_port   = 9000
+    to_port     = 9000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "MinIO console port"
+    from_port   = 9001
+    to_port     = 9001
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow all traffic within the VPC for internal communication
+  ingress {
+    description = "All traffic within VPC"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
   }
 
   egress {

--- a/terraform/set_and_var.tf
+++ b/terraform/set_and_var.tf
@@ -4,6 +4,14 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.50.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0.0"
+    }
   }
   required_version = ">=1.0"
 }


### PR DESCRIPTION
```
Key Changes Made:
- Added OIDC provider in eks_cluster.tf
- Added AWS Load Balancer Controller IAM role and policy
- Updated subnet tags for load balancer discovery
- Enhanced security group rules for MinIO ports
- Updated GitHub Actions workflow to install AWS Load Balancer Controller
- Created improved MinIO deployment with modern configuration
- Added troubleshooting guide for future reference
```